### PR TITLE
Support default_shard by adding optional configuration

### DIFF
--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -24,6 +24,9 @@ pub struct ConfigServer {
 
     #[serde(default = "defaults::server_inet")]
     pub inet: SocketAddr,
+
+    #[serde(default = "defaults::default_shard")]
+    pub default_shard: Option<u8>,
 }
 
 #[derive(Deserialize)]

--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -53,7 +53,6 @@ pub fn cache_disable_write() -> bool {
 pub fn cache_compress_body() -> bool {
     true
 }
-
 pub fn redis_host() -> String {
     "localhost".to_string()
 }
@@ -88,4 +87,8 @@ pub fn redis_max_key_size() -> usize {
 
 pub fn redis_max_key_expiration() -> usize {
     2592000
+}
+
+pub fn default_shard() -> Option<u8> {
+    None
 }

--- a/src/header/request_shard.rs
+++ b/src/header/request_shard.rs
@@ -4,6 +4,7 @@
 // Copyright: 2017, Valerian Saliou <valerian@valeriansaliou.name>
 // License: Mozilla Public License v2.0 (MPL v2.0)
 
+use crate::APP_CONF;
 use hyper::header::{parsing, Formatter, Header, Raw};
 use hyper::Result;
 use std::fmt;
@@ -17,7 +18,12 @@ impl Header for HeaderRequestBloomRequestShard {
     }
 
     fn parse_header(raw: &Raw) -> Result<HeaderRequestBloomRequestShard> {
-        parsing::from_one_raw_str(raw).map(HeaderRequestBloomRequestShard)
+        parsing::from_one_raw_str(raw)
+            .map(HeaderRequestBloomRequestShard)
+            .or_else(|e| match APP_CONF.server.default_shard {
+                Some(default) => Ok(HeaderRequestBloomRequestShard(default)),
+                None => Err(e),
+            })
     }
 
     fn fmt_header(&self, f: &mut Formatter) -> fmt::Result {

--- a/src/proxy/header.rs
+++ b/src/proxy/header.rs
@@ -9,6 +9,8 @@ use hyper::Headers;
 use std::str::from_utf8;
 use unicase::Ascii;
 
+use crate::APP_CONF;
+
 use super::defaults;
 use crate::header::request_shard::HeaderRequestBloomRequestShard;
 
@@ -24,9 +26,14 @@ impl ProxyHeader {
         }
         .to_string();
 
+        let default_shard = APP_CONF
+            .server
+            .default_shard
+            .unwrap_or(defaults::REQUEST_SHARD_DEFAULT);
+
         // Request header: 'Bloom-Request-Shard'
         let shard = match headers.get::<HeaderRequestBloomRequestShard>() {
-            None => defaults::REQUEST_SHARD_DEFAULT,
+            None => default_shard,
             Some(value) => value.0,
         };
 

--- a/src/proxy/header.rs
+++ b/src/proxy/header.rs
@@ -9,10 +9,8 @@ use hyper::Headers;
 use std::str::from_utf8;
 use unicase::Ascii;
 
-use crate::APP_CONF;
-
 use super::defaults;
-use crate::header::request_shard::HeaderRequestBloomRequestShard;
+use crate::{header::request_shard::HeaderRequestBloomRequestShard, APP_CONF};
 
 pub struct ProxyHeader;
 

--- a/src/proxy/serve.rs
+++ b/src/proxy/serve.rs
@@ -18,6 +18,7 @@ use crate::cache::write::CacheWrite;
 use crate::header::janitor::HeaderJanitor;
 use crate::header::request_shard::HeaderRequestBloomRequestShard;
 use crate::header::status::{HeaderBloomStatus, HeaderBloomStatusValue};
+use crate::APP_CONF;
 use crate::LINE_FEED;
 
 pub struct ProxyServe;
@@ -33,7 +34,10 @@ impl ProxyServe {
     pub fn handle(req: Request) -> ProxyServeResponseFuture {
         info!("handled request: {} on {}", req.method(), req.path());
 
-        if req.headers().has::<HeaderRequestBloomRequestShard>() == true {
+        let has_shard = APP_CONF.server.default_shard.is_some()
+            || req.headers().has::<HeaderRequestBloomRequestShard>();
+
+        if has_shard {
             match *req.method() {
                 Method::Options
                 | Method::Head


### PR DESCRIPTION
Hey @valeriansaliou, I've been using Bloom for some time, and it's been awesome! Thank you for building it.
In my use case, I'm running it as a sidecar on my pods in a Kubernetes cluster. I am using Istio and adding the request shard header as the request enters the cluster. 
Today I was exploring adding Bloom to another workload that could benefit from it. I stumbled into an awkward situation where I wanted to expose that service to receive external and internal traffic. I can't add headers to requests that don't pass our ingress gateway, so I thought we could satisfy #8 and my use case by providing an optional configuration to set a default shard.
If you think this change is welcome, I can try to rewrite the docs to mention it.