### PR TITLE
feat: Configuration from environment variables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "alloc-no-stdlib"
 version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -73,6 +82,7 @@ dependencies = [
  "r2d2_redis",
  "rand 0.7.3",
  "redis",
+ "regex",
  "serde",
  "serde_derive",
  "tokio-core",
@@ -794,6 +804,23 @@ checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "regex"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81ca098a9821bd52d6b24fd8b10bd081f47d39c22778cafaa75a2857a62c6390"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
 name = "relay"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ farmhash = "1.1"
 brotli = "3.3"
 rand = "0.7"
 unicase = "2.6"
+regex = "1.8.3"
 
 [profile.dev]
 opt-level = 0

--- a/README.md
+++ b/README.md
@@ -170,6 +170,29 @@ Make sure to properly configure the `[proxy]` section so that Bloom points to yo
 * `max_key_size` (type: _integer_, allowed: bytes, default: `256000`) — Maximum data size in bytes to store in Redis for a key (safeguard to prevent very large responses to be cached)
 * `max_key_expiration` (type: _integer_, allowed: seconds, default: `2592000`) — Maximum TTL for a key cached in Redis (prevents erroneous `Bloom-Response-TTL` values)
 
+#### Environment variables
+
+You are allowed to use **environment variables** in the config file. Example configuration using environment variables:
+
+```toml
+[cache]
+compress_body = "${BLOOM_COMPRESS_BODY}"
+```
+
+[redis]
+host = "${BLOOM_REDIS_HOST}"
+```
+
+And then you can run bloom providing a defined environment variable:
+
+```bash
+BLOOM_REDIS_HOST=redis.example.com \
+BLOOM_COMPRESS_BODY=false \
+./bloom -c /path/to/config.cfg
+```
+
+**It can be used only for string-like an boolean values**
+
 ### Run Bloom
 
 Bloom can be run as such:

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -7,6 +7,7 @@
 use std::net::SocketAddr;
 
 use super::defaults;
+use super::env_var;
 
 #[derive(Deserialize)]
 pub struct Config {
@@ -19,16 +20,25 @@ pub struct Config {
 
 #[derive(Deserialize)]
 pub struct ConfigServer {
-    #[serde(default = "defaults::server_log_level")]
+    #[serde(
+        default = "defaults::server_log_level",
+        deserialize_with = "env_var::str"
+    )]
     pub log_level: String,
 
-    #[serde(default = "defaults::server_inet")]
+    #[serde(
+        default = "defaults::server_inet",
+        deserialize_with = "env_var::socket_addr"
+    )]
     pub inet: SocketAddr,
 }
 
 #[derive(Deserialize)]
 pub struct ConfigControl {
-    #[serde(default = "defaults::control_inet")]
+    #[serde(
+        default = "defaults::control_inet",
+        deserialize_with = "env_var::socket_addr"
+    )]
     pub inet: SocketAddr,
 
     #[serde(default = "defaults::control_tcp_timeout")]
@@ -48,7 +58,10 @@ pub struct ConfigProxyShard {
     #[serde(default = "defaults::proxy_shard_shard")]
     pub shard: u8,
 
-    #[serde(default = "defaults::proxy_shard_host")]
+    #[serde(
+        default = "defaults::proxy_shard_host",
+        deserialize_with = "env_var::str"
+    )]
     pub host: String,
 
     #[serde(default = "defaults::proxy_shard_port")]
@@ -63,24 +76,34 @@ pub struct ConfigCache {
     #[serde(default = "defaults::cache_executor_pool")]
     pub executor_pool: u16,
 
-    #[serde(default = "defaults::cache_disable_read")]
+    #[serde(
+        default = "defaults::cache_disable_read",
+        deserialize_with = "env_var::bool"
+    )]
     pub disable_read: bool,
 
-    #[serde(default = "defaults::cache_disable_write")]
+    #[serde(
+        default = "defaults::cache_disable_write",
+        deserialize_with = "env_var::bool"
+    )]
     pub disable_write: bool,
 
-    #[serde(default = "defaults::cache_compress_body")]
+    #[serde(
+        default = "defaults::cache_compress_body",
+        deserialize_with = "env_var::bool"
+    )]
     pub compress_body: bool,
 }
 
 #[derive(Deserialize)]
 pub struct ConfigRedis {
-    #[serde(default = "defaults::redis_host")]
+    #[serde(default = "defaults::redis_host", deserialize_with = "env_var::str")]
     pub host: String,
 
     #[serde(default = "defaults::redis_port")]
     pub port: u16,
 
+    #[serde(deserialize_with = "env_var::opt_str")]
     pub password: Option<String>,
 
     #[serde(default = "defaults::redis_database")]

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -103,7 +103,7 @@ pub struct ConfigRedis {
     #[serde(default = "defaults::redis_port")]
     pub port: u16,
 
-    #[serde(deserialize_with = "env_var::opt_str")]
+    #[serde(default, deserialize_with = "env_var::opt_str")]
     pub password: Option<String>,
 
     #[serde(default = "defaults::redis_database")]

--- a/src/config/env_var.rs
+++ b/src/config/env_var.rs
@@ -99,10 +99,8 @@ fn get_env_var_bool(wrapped_key: &str) -> bool {
         .unwrap_or_else(|_| panic!("env_var: variable '{}' is not set", key))
         .to_lowercase();
     match value.as_ref() {
-        "0" => false,
-        "1" => true,
-        "true" => true,
-        "false" => false,
+        "0" | "false" => false,
+        "1" | "true" => true,
         _ => panic!("env_var: variable '{}' is not a boolean", key),
     }
 }

--- a/src/config/env_var.rs
+++ b/src/config/env_var.rs
@@ -1,0 +1,111 @@
+// Bloom
+//
+// HTTP REST API caching middleware
+// Copyright: 2017, Valerian Saliou <valerian@valeriansaliou.name>
+// License: Mozilla Public License v2.0 (MPL v2.0)
+
+use regex::Regex;
+use serde::{Deserialize, Deserializer};
+use std::net::SocketAddr;
+use std::path::PathBuf;
+
+#[derive(Deserialize, PartialEq)]
+struct WrappedString(String);
+
+pub fn str<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = String::deserialize(deserializer)?;
+
+    match is_env_var(&value) {
+        true => Ok(get_env_var(&value)),
+        false => Ok(value),
+    }
+}
+
+pub fn opt_str<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Option::<WrappedString>::deserialize(deserializer).map(|option: Option<WrappedString>| {
+        option.map(|wrapped: WrappedString| {
+            let value = wrapped.0;
+
+            match is_env_var(&value) {
+                true => get_env_var(&value),
+                false => value,
+            }
+        })
+    })
+}
+
+pub fn socket_addr<'de, D>(deserializer: D) -> Result<SocketAddr, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = String::deserialize(deserializer)?;
+
+    match is_env_var(&value) {
+        true => Ok(get_env_var(&value).parse().unwrap()),
+        false => Ok(value.parse().unwrap()),
+    }
+}
+
+pub fn path_buf<'de, D>(deserializer: D) -> Result<PathBuf, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = String::deserialize(deserializer)?;
+
+    match is_env_var(&value) {
+        true => Ok(PathBuf::from(get_env_var(&value))),
+        false => Ok(PathBuf::from(value)),
+    }
+}
+
+fn is_env_var(value: &str) -> bool {
+    Regex::new(r"^\$\{[A-Z_0-9]+\}$")
+        .expect("env_var: regex is invalid")
+        .is_match(value)
+}
+
+fn get_env_var(wrapped_key: &str) -> String {
+    let key: String = String::from(wrapped_key)
+        .drain(2..(wrapped_key.len() - 1))
+        .collect();
+
+    std::env::var(key.clone()).unwrap_or_else(|_| panic!("env_var: variable '{}' is not set", key))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_checks_environment_variable_patterns() {
+        assert!(is_env_var("${XXX}"));
+        assert!(is_env_var("${XXX_123}"));
+        assert!(is_env_var("${123}"));
+        assert!(is_env_var("${1_23}"));
+        assert!(!is_env_var("${XXX"));
+        assert!(!is_env_var("${XXX}a"));
+        assert!(!is_env_var("a${XXX}"));
+        assert!(!is_env_var("{XXX}"));
+        assert!(!is_env_var("$XXX}"));
+        assert!(!is_env_var("${envXXX}"));
+        assert!(!is_env_var("${.XXX}"));
+        assert!(!is_env_var("${XXX.}"));
+        assert!(!is_env_var("${éíá}"));
+        assert!(!is_env_var("${ÉÍÁ}"));
+    }
+
+    #[test]
+    fn it_gets_environment_variable() {
+        std::env::set_var("TEST", "test");
+
+        assert_eq!(get_env_var("${TEST}"), "test");
+
+        std::env::remove_var("TEST");
+    }
+}

--- a/src/config/env_var.rs
+++ b/src/config/env_var.rs
@@ -62,7 +62,11 @@ where
             true => get_env_var_bool(&s),
             false => s.parse().unwrap(),
         },
-        _ => return Err(de::Error::custom("Wrong type, expected boolean, string or env var")),
+        _ => {
+            return Err(de::Error::custom(
+                "Wrong type, expected boolean, string or env var",
+            ))
+        }
     })
 }
 

--- a/src/config/env_var.rs
+++ b/src/config/env_var.rs
@@ -7,7 +7,6 @@
 use regex::Regex;
 use serde::{Deserialize, Deserializer};
 use std::net::SocketAddr;
-use std::path::PathBuf;
 
 #[derive(Deserialize, PartialEq)]
 struct WrappedString(String);
@@ -52,19 +51,7 @@ where
     }
 }
 
-pub fn path_buf<'de, D>(deserializer: D) -> Result<PathBuf, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let value = String::deserialize(deserializer)?;
-
-    match is_env_var(&value) {
-        true => Ok(PathBuf::from(get_env_var_str(&value))),
-        false => Ok(PathBuf::from(value)),
-    }
-}
-
-pub fn bool<'de,D>(deserializer: D) -> Result<bool, D::Error>
+pub fn bool<'de, D>(deserializer: D) -> Result<bool, D::Error>
 where
     D: Deserializer<'de>,
 {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -5,6 +5,7 @@
 // License: Mozilla Public License v2.0 (MPL v2.0)
 
 mod defaults;
+mod env_var;
 
 pub mod config;
 pub mod logger;

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,10 +22,10 @@ extern crate r2d2;
 extern crate r2d2_redis;
 extern crate rand;
 extern crate redis;
+extern crate regex;
 extern crate tokio_core;
 extern crate toml;
 extern crate unicase;
-extern crate regex;
 
 mod cache;
 mod config;

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,7 @@ extern crate redis;
 extern crate tokio_core;
 extern crate toml;
 extern crate unicase;
+extern crate regex;
 
 mod cache;
 mod config;


### PR DESCRIPTION
This pull request introduces a new feature that allows passing configuration settings from environment variables. The implementation of this feature has been adapted from [sonic](https://github.com/valeriansaliou/sonic/blob/master/src/config/env_var.rs), with some modifications to align with the UNIX specification for environment variable keys and to support boolean values from environment variables as well.

The changes in this pull request have been tested locally with a sample config from the repository and a modified config using environment variables for a few config values such as `redis.host` and cache behaviour boolean flags. With both configurations and correctly provided environment variables, bloom can start and connect to Redis.

Please review the changes and provide feedback or suggestions for improvements. I would greatly appreciate any input you could give me since this was my first encounter with rust.

Fixes #21 